### PR TITLE
Fix the wrong CIDR range example.

### DIFF
--- a/hadoop-common-project/hadoop-common/src/site/markdown/Superusers.md
+++ b/hadoop-common-project/hadoop-common/src/site/markdown/Superusers.md
@@ -80,7 +80,7 @@ If more lax security is preferred, the wildcard value \* may be used to allow im
         <value>*</value>
       </property>
 
-The `hadoop.proxyuser.$superuser.hosts` accepts list of ip addresses, ip address ranges in CIDR format and/or host names. For example, by specifying as below, user named `super` accessing from hosts in the range `10.222.0.0-15` and `10.113.221.221` can impersonate `user1` and `user2`.
+The `hadoop.proxyuser.$superuser.hosts` accepts list of ip addresses, ip address ranges in CIDR format and/or host names. For example, by specifying as below, user named `super` accessing from hosts in the range `10.222.0.0-10.222.255.255` and `10.113.221.221` can impersonate `user1` and `user2`.
 
        <property>
          <name>hadoop.proxyuser.super.hosts</name>


### PR DESCRIPTION
The CIDR range example on the Proxy user description page is wrong.
 

In the Configurations section of Proxy user page, CIDR format 10.222.0.0/16 means 10.222.0.0-15.
 

But It's not true. the CIDR format 10.222.0.0/16 means 10.222.0.0-10.222.255.255.